### PR TITLE
Updated the framework version and some packages.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ executors:
       - image: "hashicorp/terraform:light"
   docker-dotnet:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:3.1
+      - image: mcr.microsoft.com/dotnet/sdk:6.0
 
 references:
   workspace_root: &workspace_root "~"
@@ -70,7 +70,7 @@ commands:
       - run:
           name: Install Node.js
           command: |
-            curl -sL https://deb.nodesource.com/setup_13.x | bash -
+            curl -sL https://deb.nodesource.com/setup_14.x | bash -
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI

--- a/FinanceChargesListener.Tests/Dockerfile
+++ b/FinanceChargesListener.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'

--- a/FinanceChargesListener.Tests/FinanceChargesListener.Tests.csproj
+++ b/FinanceChargesListener.Tests/FinanceChargesListener.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>

--- a/FinanceChargesListener.Tests/FinanceChargesListener.Tests.csproj
+++ b/FinanceChargesListener.Tests/FinanceChargesListener.Tests.csproj
@@ -19,7 +19,7 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/FinanceChargesListener/Dockerfile
+++ b/FinanceChargesListener/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 ARG LBHPACKAGESTOKEN
 ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN

--- a/FinanceChargesListener/FinanceChargesListener.csproj
+++ b/FinanceChargesListener/FinanceChargesListener.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="6.0.0" />
     <PackageReference Include="Hackney.Shared.Asset" Version="0.7.0" />
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="6.0.5" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/FinanceChargesListener/FinanceChargesListener.csproj
+++ b/FinanceChargesListener/FinanceChargesListener.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
 
@@ -27,14 +27,14 @@
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="6.0.0" />
     <PackageReference Include="Hackney.Shared.Asset" Version="0.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="6.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="6.0.5" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="NEST" Version="7.15.0" />

--- a/FinanceChargesListener/aws-lambda-tools-defaults.json
+++ b/FinanceChargesListener/aws-lambda-tools-defaults.json
@@ -8,8 +8,8 @@
   "profile": "default",
   "region": "eu-west-2",
   "configuration": "Release",
-  "framework": "netcoreapp3.1",
-  "function-runtime": "dotnetcore3.1",
+  "framework": "net6.0",
+  "function-runtime": "dotnet6",
   "function-memory-size": 256,
   "function-timeout": 30,
   "function-handler": "FinanceChargesListener::FinanceChargesListener.ChargesListener::FunctionHandler"

--- a/FinanceChargesListener/build.cmd
+++ b/FinanceChargesListener/build.cmd
@@ -1,2 +1,2 @@
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package bin/release/netcoreapp3.1/finance-charges-listener.zip
+dotnet lambda package --configuration release --framework net6.0 --output-package bin/release/net6.0/finance-charges-listener.zip

--- a/FinanceChargesListener/build.sh
+++ b/FinanceChargesListener/build.sh
@@ -18,4 +18,4 @@ then
 fi
 
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package ./bin/release/netcoreapp3.1/finance-charges-listener.zip
+dotnet lambda package --configuration release --framework net6.0 --output-package ./bin/release/net6.0/finance-charges-listener.zip

--- a/FinanceChargesListener/serverless.yml
+++ b/FinanceChargesListener/serverless.yml
@@ -1,7 +1,7 @@
 service: finance-charges-listener
 provider:
   name: aws
-  runtime: dotnetcore3.1
+  runtime: dotnet6
   memorySize: 3008
   timeout: 900
   tracing:
@@ -12,7 +12,7 @@ provider:
   region: eu-west-2
 
 package:
-  artifact: ./bin/release/netcoreapp3.1/finance-charges-listener.zip
+  artifact: ./bin/release/net6.0/finance-charges-listener.zip
 
 functions:
   FinanceChargesListener:


### PR DESCRIPTION
# What:
 - An upgrade of the dotnet version from 3.1 to 6.
 - An upgrade of some of the packages that are needed for the newer version to get deployed/run.

# Why:
 - It's a mandatory piece of work due to security as the current (3.1) version is reaching its end of life.
 - Better performance.
 - Newer features & syntax.