### PR TITLE
Removed duplicate package reference.

### DIFF
--- a/FinanceChargesListener/FinanceChargesListener.csproj
+++ b/FinanceChargesListener/FinanceChargesListener.csproj
@@ -25,9 +25,8 @@
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.5.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
-    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="6.0.0" />
     <PackageReference Include="Hackney.Shared.Asset" Version="0.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="6.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="6.0.8" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
# What:
 - Removed duplicate package reference.

# Why:
 - It was causing a build error _(see CCI [logs](https://app.circleci.com/pipelines/github/LBHackney-IT/finance-charges-listener/235/workflows/30d3ca02-2177-4d7a-b132-ed4d9211f474/jobs/822))_.

# Notes:
 - It's not clear why, but the error did not appear during a test run on a feature branch. Regardless, it was easy to fix. I've tested the pipeline's response to this change on a now deleted dummy branch.
 - I have also upgraded the version of the non-redundant package reference entry to the latest patch as there's no harm in that.
 - The whole application has only 2 tests, so treat the successful test run with a grain of salt.