### PR TITLE
Upgraded version of Hackney.Asset.Shared to 0.30 and Hackney.Core.DynamoDb to 1.79

### DIFF
--- a/FinanceChargesListener/FinanceChargesListener.csproj
+++ b/FinanceChargesListener/FinanceChargesListener.csproj
@@ -21,11 +21,11 @@
     <PackageReference Include="AWSSDK.S3" Version="3.7.7.19" />
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.8.3" />
     <PackageReference Include="ExcelDataReader" Version="3.6.0" />
-    <PackageReference Include="Hackney.Core.DynamoDb" Version="1.30.0" />
+    <PackageReference Include="Hackney.Core.DynamoDb" Version="1.79.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.5.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.7.0" />
+    <PackageReference Include="Hackney.Shared.Asset" Version="0.30.0" />
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="6.0.8" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/FinanceChargesListener/UseCase/Utility/Helper.cs
+++ b/FinanceChargesListener/UseCase/Utility/Helper.cs
@@ -33,7 +33,7 @@ namespace FinanceChargesListener.UseCase.Utility
             {
                 if (asset.AssetCharacteristics != null)
                 {
-                    var scFactor = GetScFactor(asset.AssetCharacteristics.NumberOfBedrooms);
+                    var scFactor = GetScFactor(asset.AssetCharacteristics.NumberOfBedrooms ?? 0);
                     calculatedList.Add(asset.Id, scFactor);
                 }
             }


### PR DESCRIPTION
## Link to JIRA ticket

MR-698 - https://hackney.atlassian.net/jira/software/c/projects/MR/boards/88?modal=detail&selectedIssue=MR-698

## Describe this PR

### *What is the problem we're trying to solve*

While working on the New Asset Form (MMH) we've noticed that, when saving a new asset, a lot of other properties are added to it.
An asset can have so many properties, however the New Asset Form only captures some of these. The issue is with the properties we're not capturing, especially the ones of type int and boolean, as a default value is assigned, which can be misleading for example:
`numberOfShowers` is saved with a `0` value or a boolean property such as `hasRampAccess` is saved as `false` - these are fields the values of which we're NOT capturing in the form, but if someone was to look at the asset in the database, they would find misleading information.
For the above examples, as we're not capturing those properties (or they're optional in the 'New asset' form), we'd want their values to be null, rather than use default values (0s and false's).

### *What changes have we introduced*

- Reviewed where Hackney.Asset.Shared is used in this repo
- Added null coalescing operator in Helper.cs as NumberOfBedrooms can now be null
- Upgraded version of Hackney.Core.DynamoDb to 1.79
- Upgraded version of Hackney.Asset.Shared to 0.30

### *Changes introduced by in Hackney.Asset.Shared*
Properties within the AssetDb class (within Hackney.Asset.Shared) of type 'int' and 'boolean' have been set from non-nullable to nullable with the latest update of the library, to version 0.30.

ON HOLD - Check Hackney.Core.DynamoDb