### PR TITLE
Remove needless CODEOWNERS file.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,0 @@
-# doc for this file https://help.github.com/articles/about-code-owners/
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
-
-* @LBHMGeorgieva @LBHMKeyworth @LBHSPreston @LBHRShetty @LBHackney-IT/mtfh-finance


### PR DESCRIPTION
# What:
 - Remove CODEOWNERS file.

# Why:
 - None of the people listed are in the development team anymore.
 - The team name listed is meaningless as there has been a team merger since that is not limited to finance. A new team is such that anyone should be able to take on anything.

# Notes:
 - The build is showing as failing because of expired SSH key. Will fix that as soon as CODEOWNERS is taken care of.