### PR TITLE
Add feature workflow and add Terraform changes preview.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,6 @@
 version: 2.1
 
 orbs:
-  aws-ecr: circleci/aws-ecr@3.0.0
-  aws-cli: circleci/aws-cli@0.1.9
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,6 +151,21 @@ jobs:
     steps:
       - terraform-init-then-apply:
           environment: "production"
+  preview-development-terraform:
+    executor: docker-terraform
+    steps:
+      - preview-terraform:
+          environment: "development"
+  preview-staging-terraform:
+    executor: docker-terraform
+    steps:
+      - preview-terraform:
+          environment: "staging"
+  preview-production-terraform:
+    executor: docker-terraform
+    steps:
+      - preview-terraform:
+          environment: "production"
   deploy-to-development:
     executor: docker-dotnet
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,6 +183,24 @@ jobs:
           stage: "production"
 
 workflows:
+  feature:
+    jobs:
+      - check-code-formatting:
+          context: api-nuget-token-context
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - build-and-test:
+          context: 
+            - api-nuget-token-context
+            - SonarCloud
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
   check-and-deploy-development:
     jobs:
       - check-code-formatting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,12 +55,26 @@ commands:
           command: |
             cd ./terraform/<<parameters.environment>>/
             terraform apply -auto-approve
+  preview-terraform:
+    description: "Preview terraform configuration changes"
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform get -update=true
+            terraform init
+            terraform plan
+          name: preview terraform
   deploy-lambda:
     description: "Deploys via Serverless"
     parameters:
       stage:
         type: string
-
     steps:
       - *attach_workspace
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,10 +187,16 @@ workflows:
     jobs:
       - check-code-formatting:
           context: api-nuget-token-context
+          filters:
+            branches:
+              only: development
       - build-and-test:
           context:
             - api-nuget-token-context
             - SonarCloud
+          filters:
+            branches:
+              only: development
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,9 +188,9 @@ workflows:
       - check-code-formatting:
           context: api-nuget-token-context
       - build-and-test:
-          context: 
+          context:
             - api-nuget-token-context
-            - SonarCloud           
+            - SonarCloud
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:
@@ -220,9 +220,9 @@ workflows:
             branches:
               only: master
       - build-and-test:
-          context: 
+          context:
             - api-nuget-token-context
-            - SonarCloud           
+            - SonarCloud
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,6 +201,51 @@ workflows:
               ignore:
                 - development
                 - master
+      - assume-role-development:
+          context: api-assume-role-housing-development-context
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - preview-development-terraform:
+          requires:
+            - assume-role-development
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - assume-role-staging:
+          context: api-assume-role-housing-staging-context
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - preview-staging-terraform:
+          requires:
+            - assume-role-staging
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - assume-role-production:
+          context: api-assume-role-housing-production-context
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - preview-production-terraform:
+          requires:
+            - assume-role-production
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
   check-and-deploy-development:
     jobs:
       - check-code-formatting:


### PR DESCRIPTION
# What:
 - Add feature branch CCI workflow.
 - Restrict development workflow steps to run strictly on development branch triggers.
 - Add terraform preview.

# Why:
 - With increasing number of scripts being run against AWS to modify infrastructure on mass, plus ongoing manual edits to these same resources, it becomes difficult to trust in up-to-dateness of Terraform file within the repository. Deploying these changes blind is like buying bags where some of them contain cats. As such, Terraform preview was added to get a rough idea of what to expect when doing any kind of code deployment.

# Notes:
 - Production preview step failure is expected. It's not an issue.