### PR TITLE
Fix sonar cloud failing due to dated JRE version.

### DIFF
--- a/FinanceChargesListener.Tests/Dockerfile
+++ b/FinanceChargesListener.Tests/Dockerfile
@@ -13,7 +13,7 @@ ENV SONAR_TOKEN=$SONAR_TOKEN
 WORKDIR /app
 
 # Enable SonarCloud
-RUN apt-get update && apt-get install -y openjdk-11-jdk
+RUN apt-get update && apt-get install -y openjdk-17-jdk
 RUN dotnet tool install --global dotnet-sonarscanner
 ENV PATH="$PATH:/root/.dotnet/tools"
 


### PR DESCRIPTION
# What:
 - Upgrade Java SDK from v11 to v17.

# Why:
 - So that Sonar Cloud package would have the minimum Java Runtime version it needs.

# Notes:
 - The build is failing because the dotnet 8 upgrade is still in progress. That doesn't matter in the context of this PR, however.